### PR TITLE
Features/350 support typeof literal

### DIFF
--- a/src/UnitTestCoder.Core.Tests/Literals/ValueLiteralMakerTests.cs
+++ b/src/UnitTestCoder.Core.Tests/Literals/ValueLiteralMakerTests.cs
@@ -180,11 +180,42 @@ namespace Didsbury.Tests.CodeGen
             _valueLiteralMaker.Literal(arg).ShouldBe("Didsbury.Tests.CodeGen.ValueLiteralMakerTests.Nested.NestedEnum.Default");
         }
 
-        public class Nested
+        public partial class Nested
         {
             public enum NestedEnum
             {
                 Default = 1
+            }
+        }
+
+        [TestMethod]
+        public void ValueLiteralMakerType()
+        {
+            var arg = typeof(string);
+
+            _valueLiteralMaker.Literal(arg).ShouldBe("typeof(System.String)");
+        }
+
+        [TestMethod]
+        public void ValueLiteralMakerSubType()
+        {
+            var arg = typeof(System.Globalization.Calendar);
+
+            _valueLiteralMaker.Literal(arg).ShouldBe("typeof(System.Globalization.Calendar)");
+        }
+
+        [TestMethod]
+        public void ValueLiteralMakerNestedType()
+        {
+            var arg = typeof(Nested.Subclass);
+
+            _valueLiteralMaker.Literal(arg).ShouldBe("typeof(Didsbury.Tests.CodeGen.ValueLiteralMakerTests.Nested.Subclass)");
+        }
+
+        public partial class Nested
+        {
+            public class Subclass
+            {
             }
         }
     }

--- a/src/UnitTestCoder.Core/Literals/ValueLiteralMaker.cs
+++ b/src/UnitTestCoder.Core/Literals/ValueLiteralMaker.cs
@@ -167,7 +167,11 @@ namespace UnitTestCoder.Core.Literal
 
         public bool CanMake(Type type)
         {
-            if(type.IsValueType || type == typeof(string) || type == typeof(byte[]) || type == typeof(string[]))
+            if(type.IsValueType 
+                || type == typeof(string) 
+                || type == typeof(byte[]) 
+                || type == typeof(string[])
+                || type == typeof(Type))
                 return true;
 
             return false;

--- a/src/UnitTestCoder.Core/Literals/ValueLiteralMaker.cs
+++ b/src/UnitTestCoder.Core/Literals/ValueLiteralMaker.cs
@@ -74,7 +74,16 @@ namespace UnitTestCoder.Core.Literal
                 return $"{typeFullName}.{Enum.GetName(type, arg)}";
             }
 
-            throw new Exception("Unexpected data type");
+            if(arg is Type)
+            {
+                // For nested types repace + notation with .
+                var argType = (Type)arg;
+                string fullName = ((Type)arg).FullName.Replace("+", ".");
+
+                return $"typeof({fullName})";
+            }
+
+            throw new Exception($"Unexpected data type {type}");
         }
 
         private string stringLiteral(object arg)

--- a/src/UnitTestCoder.Shouldly.Tests/Maker/ShouldlyTestMakerTests.cs
+++ b/src/UnitTestCoder.Shouldly.Tests/Maker/ShouldlyTestMakerTests.cs
@@ -279,6 +279,21 @@ namespace UnitTestCoder.Shouldly.Tests.Maker
             x[0].ShouldBe("arg.IncludeThis.ShouldBe(123);");
         }
 
+        [TestMethod]
+        public void ShouldlyTestMakerType()
+        {
+            var myObj = new
+            {
+                StringType = typeof(string)
+            };
+
+            var x = _shouldlyTestMaker.GenerateShouldBes("myObj", myObj).ToList();
+
+            x.Count().ShouldBe(1);
+
+            x[0].ShouldBe(@"myObj.StringType.ShouldBe(typeof(System.String));");
+        }
+
         public class NoFollowTestClass
         {
             public int IncludeThis { get; set; }


### PR DESCRIPTION
Supports types when they are exposed as a property:

abc.SomethingType.ShouldBe(typeof(string));