### PR TITLE
Features/typeof in literals

### DIFF
--- a/src/UnitTestCoder.Core.Tests/Literals/ObjectLiteralMakerTests.cs
+++ b/src/UnitTestCoder.Core.Tests/Literals/ObjectLiteralMakerTests.cs
@@ -66,7 +66,7 @@ namespace UnitTestCoder.Core.Tests.Literals
                     "B",
                 });
 
-            result.ShouldBe(normalise(@"new List<String>() { ""A"", ""B"", }"));
+            result.ShouldBe(normalise(@"new List<string>() { ""A"", ""B"", }"));
         }
 
         [TestMethod]
@@ -214,7 +214,7 @@ namespace UnitTestCoder.Core.Tests.Literals
             var m = typeof(string);
 
             var result = makeObjectLiteral(m);
-            result.ShouldBe("typeof(System.String)");
+            result.ShouldBe("typeof(string)");
         }
 
         [TestMethod]
@@ -223,7 +223,7 @@ namespace UnitTestCoder.Core.Tests.Literals
             var pq = new TypeofObject() { T = typeof(string) };
 
             var result = makeObjectLiteral(pq);
-            result.ShouldBe("new TypeofObject() { T = typeof(System.String), }");
+            result.ShouldBe("new TypeofObject() { T = typeof(string), }");
         }
 
         [TestMethod]

--- a/src/UnitTestCoder.Core.Tests/Literals/TypeLiteralMakerTests.cs
+++ b/src/UnitTestCoder.Core.Tests/Literals/TypeLiteralMakerTests.cs
@@ -23,7 +23,7 @@ namespace UnitTestCoder.Core.Tests.Literals
         {
             var arg = typeof(string);
 
-            _typeLiteralMaker.Literal(arg).ShouldBe("typeof(System.String)");
+            _typeLiteralMaker.Literal(arg).ShouldBe("typeof(string)");
         }
 
         [TestMethod]
@@ -75,7 +75,7 @@ namespace UnitTestCoder.Core.Tests.Literals
         {
             var arg = typeof(List<string>);
 
-            _typeLiteralMaker.Literal(arg).ShouldBe("typeof(System.Collections.Generic.List<System.String>)");
+            _typeLiteralMaker.Literal(arg).ShouldBe("typeof(System.Collections.Generic.List<string>)");
         }
     }
 }

--- a/src/UnitTestCoder.Core.Tests/Literals/TypeLiteralMakerTests.cs
+++ b/src/UnitTestCoder.Core.Tests/Literals/TypeLiteralMakerTests.cs
@@ -27,7 +27,7 @@ namespace UnitTestCoder.Core.Tests.Literals
         }
 
         [TestMethod]
-        public void ValueLiteralMakerSubType()
+        public void TypeLiteralMakerSubType()
         {
             var arg = typeof(System.Globalization.Calendar);
 
@@ -35,18 +35,47 @@ namespace UnitTestCoder.Core.Tests.Literals
         }
 
         [TestMethod]
-        public void ValueLiteralMakerNestedType()
+        public void TypeLiteralMakerNestedType()
         {
             var arg = typeof(Nested.Subclass);
 
             _typeLiteralMaker.Literal(arg).ShouldBe("typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.Subclass)");
         }
 
+        [TestMethod]
+        public void TypeLiteralMakerNestedGenericType()
+        {
+            var arg = typeof(Nested.GenericSub<>);
+
+            _typeLiteralMaker.Literal(arg).ShouldBe("typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<>)");
+        }
+
+
         public partial class Nested
         {
             public class Subclass
             {
             }
+
+            public class GenericSub<T>
+            {
+            }
+        }
+
+        [TestMethod]
+        public void TypeLiteralMakerGenericOpenConstructed()
+        {
+            var arg = typeof(IDictionary<,>);
+
+            _typeLiteralMaker.Literal(arg).ShouldBe("typeof(System.Collections.Generic.IDictionary<,>)");
+        }
+
+        [TestMethod]
+        public void TypeLiteralMakerGenericClosedConstructed()
+        {
+            var arg = typeof(List<string>);
+
+            _typeLiteralMaker.Literal(arg).ShouldBe("typeof(System.Collections.Generic.List<System.String>)");
         }
     }
 }

--- a/src/UnitTestCoder.Core.Tests/Literals/TypeNameLiteralMakerTests.cs
+++ b/src/UnitTestCoder.Core.Tests/Literals/TypeNameLiteralMakerTests.cs
@@ -111,6 +111,61 @@ namespace UnitTestCoder.Core.Tests.Literals
                 .ShouldBe(false);
         }
 
+        [TestMethod]
+        public void TypeNameLiteralString()
+        {
+            _typeNameLiteralMaker
+                .Literal(typeof(string), fullyQualify: true)
+                .ShouldBe("string");
+        }
+
+        [TestMethod]
+        public void TypeNameLiteralInt()
+        {
+            _typeNameLiteralMaker
+                .Literal(typeof(int), fullyQualify: true)
+                .ShouldBe("int");
+        }
+
+        [TestMethod]
+        public void TypeNameLiteralNullableInt()
+        {
+            _typeNameLiteralMaker
+                .Literal(typeof(int?), fullyQualify: true)
+                .ShouldBe("int?");
+        }
+
+        [TestMethod]
+        public void TypeNameLiteralStringArray()
+        {
+            _typeNameLiteralMaker
+                .Literal(typeof(string[]), fullyQualify: true)
+                .ShouldBe("string[]");
+        }
+
+        [TestMethod]
+        public void TypeNameLiteralStringArray2D()
+        {
+            _typeNameLiteralMaker
+                .Literal(typeof(string[,]), fullyQualify: true)
+                .ShouldBe("string[,]");
+        }
+
+        [TestMethod]
+        public void TypeNameLiteralObject()
+        {
+            _typeNameLiteralMaker
+                .Literal(typeof(object), fullyQualify: true)
+                .ShouldBe("object");
+        }
+
+        [TestMethod]
+        public void TypeNameLiteralArrayOfNested()
+        {
+            _typeNameLiteralMaker
+                .Literal(typeof(NormalClass.NestedClass[,]), fullyQualify: false)
+                .ShouldBe("NormalClass.NestedClass[,]");
+        }
     }
 
     public class NormalClass

--- a/src/UnitTestCoder.Core/Gen/ObjectLiteral.cs
+++ b/src/UnitTestCoder.Core/Gen/ObjectLiteral.cs
@@ -59,9 +59,11 @@ namespace UnitTestCoder.Core.Gen
 
             var valueLiteralMaker = new ValueLiteralMaker();
             var typeNameLiteralMaker = new TypeNameLiteralMaker();
+            var typeLiteralMaker = new TypeLiteralMaker(typeNameLiteralMaker);
             var objectLiteralMaker = new ObjectLiteralMaker(
                 valueLiteralMaker,
                 typeNameLiteralMaker,
+                typeLiteralMaker,
                 indenter);
 
             var objectLiteralCoder = new ObjectLiteralCoder(

--- a/src/UnitTestCoder.Shouldly.Tests/Maker/ShouldlyTestMakerTests.cs
+++ b/src/UnitTestCoder.Shouldly.Tests/Maker/ShouldlyTestMakerTests.cs
@@ -381,7 +381,7 @@ namespace UnitTestCoder.Shouldly.Tests.Maker
             x.ShouldBe(new[]
             {
                 "myObj.ShouldNotBeNull();",
-                "myObj.StringType.ShouldBe(typeof(System.String));"
+                "myObj.StringType.ShouldBe(typeof(string));"
             });
         }
 


### PR DESCRIPTION
Added support for typeof() literals in ObjectLiteral.Gen.
Uses simple type names where possible e.g. "string" not "System.String"