### PR TITLE
Features/25 incorrect use of is assignable from

### DIFF
--- a/src/UnitTestCoder.Core.Tests/Literals/ObjectLiteralMakerTests.cs
+++ b/src/UnitTestCoder.Core.Tests/Literals/ObjectLiteralMakerTests.cs
@@ -199,6 +199,21 @@ namespace UnitTestCoder.Core.Tests.Literals
         }
 
         [TestMethod]
+        public void ObjectLiteralMakerSkipItemProperty()
+        {
+            var pq = new WithItemProperty() { Other = 123 };
+
+            var result = makeObjectLiteral(pq);
+            result.ShouldBe("new ObjectLiteralMakerTests.WithItemProperty() { Other = 123, }");
+        }
+
+        private class WithItemProperty // NOT defined as IEnumerable / IList
+        {
+            public int this[int x] { get => 99; set { } }
+            public int Other { get; set; }
+        }
+
+        [TestMethod]
         public void ObjectLiteralMakerNoFollow()
         {
             var m = new ObjectABC() { A = 1, B = 2, C = 3 };

--- a/src/UnitTestCoder.Core.Tests/Literals/TypeLiteralMakerTests.cs
+++ b/src/UnitTestCoder.Core.Tests/Literals/TypeLiteralMakerTests.cs
@@ -79,6 +79,15 @@ namespace UnitTestCoder.Core.Tests.Literals
                 "typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<int>.GenericWithinGeneric<string>)");
         }
 
+        [TestMethod]
+        public void TypeLiteralMakerNestedConstructedWithSelf()
+        {
+            var arg = typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.Subclass>.GenericWithinGeneric<string>);
+
+            _typeLiteralMaker.Literal(arg).ShouldBe(
+                "typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.Subclass>.GenericWithinGeneric<string>)");
+        }
+
 
         public partial class Nested
         {

--- a/src/UnitTestCoder.Core.Tests/Literals/TypeLiteralMakerTests.cs
+++ b/src/UnitTestCoder.Core.Tests/Literals/TypeLiteralMakerTests.cs
@@ -45,9 +45,38 @@ namespace UnitTestCoder.Core.Tests.Literals
         [TestMethod]
         public void TypeLiteralMakerNestedGenericType()
         {
-            var arg = typeof(Nested.GenericSub<>);
+            var arg = typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<>);
 
-            _typeLiteralMaker.Literal(arg).ShouldBe("typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<>)");
+            _typeLiteralMaker.Literal(arg).ShouldBe(
+                "typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<>)");
+        }
+
+        [TestMethod]
+        public void TypeLiteralMakerNestedSubWithinGeneric()
+        {
+            var arg = typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<>.SubWithinGeneric);
+
+            _typeLiteralMaker.Literal(arg).ShouldBe(
+                "typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<>.SubWithinGeneric)");
+        }
+
+        [TestMethod]
+        public void TypeLiteralMakerNestedGenericWithinGeneric()
+        {
+            var arg = typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<>.GenericWithinGeneric<>);
+
+            _typeLiteralMaker.Literal(arg).ShouldBe(
+                "typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<>.GenericWithinGeneric<>)");
+        }
+
+
+        [TestMethod]
+        public void TypeLiteralMakerNestedConstructedGenericWithinGeneric()
+        {
+            var arg = typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<int>.GenericWithinGeneric<string>);
+
+            _typeLiteralMaker.Literal(arg).ShouldBe(
+                "typeof(UnitTestCoder.Core.Tests.Literals.TypeLiteralMakerTests.Nested.GenericSub<int>.GenericWithinGeneric<string>)");
         }
 
 
@@ -59,6 +88,9 @@ namespace UnitTestCoder.Core.Tests.Literals
 
             public class GenericSub<T>
             {
+                public class SubWithinGeneric { }
+
+                public class GenericWithinGeneric<T2> { }
             }
         }
 

--- a/src/UnitTestCoder.Core/Decomposer/ObjectDecomposer.cs
+++ b/src/UnitTestCoder.Core/Decomposer/ObjectDecomposer.cs
@@ -149,6 +149,11 @@ namespace UnitTestCoder.Core.Decomposer
                                     continue;
 
                                 var getMethod = prop.GetGetMethod();
+
+                                // We can't do anything with parameterised calls e.g. .Item[int32]
+                                if(getMethod.GetParameters().Length > 0)
+                                    continue;
+
                                 object val = getMethod.Invoke(arg, null);
 
                                 string newLValue = $"{lvalue}.{propertyName}";

--- a/src/UnitTestCoder.Core/Decomposer/ObjectDecomposer.cs
+++ b/src/UnitTestCoder.Core/Decomposer/ObjectDecomposer.cs
@@ -75,7 +75,7 @@ namespace UnitTestCoder.Core.Decomposer
                         // Remember this object in case we see it again.
                         seenObjects.Add(arg, lvalue);
 
-                        if(typeof(IDictionary).IsAssignableFrom(type))
+                        if(arg is IDictionary)
                         {
                             var dict = ((IDictionary)arg);
 
@@ -104,9 +104,7 @@ namespace UnitTestCoder.Core.Decomposer
 
                             yield return dictionaryEnd(lvalue, type, dict.Count);
                         }
-                        else if(typeof(IList).IsAssignableFrom(type)
-                            || typeof(IList<>).IsAssignableFrom(type)
-                            )
+                        else if(arg is IList || typeof(IList<>).IsInstanceOfType(arg))
                         {
                             var list = ((IEnumerable)arg).Cast<object>().ToList();
 

--- a/src/UnitTestCoder.Core/Literals/ObjectLiteralMaker.cs
+++ b/src/UnitTestCoder.Core/Literals/ObjectLiteralMaker.cs
@@ -121,17 +121,22 @@ namespace UnitTestCoder.Core.Literal
                             {
                                 // Read the current value of the property
                                 var getMethod = prop.GetGetMethod();
-                                object val = getMethod.Invoke(arg, null);
 
-                                yield return space();
-
-                                yield return $"{name} = ";
-
-                                foreach(var result in objLiteral(val, nesting, noFollowFunc, seenObjects))
+                                // We can't do anything with parameterised calls e.g. .Item[int32]
+                                if(getMethod.GetParameters().Length == 0)
                                 {
-                                    yield return result;
+                                    object val = getMethod.Invoke(arg, null);
+
+                                    yield return space();
+
+                                    yield return $"{name} = ";
+
+                                    foreach(var result in objLiteral(val, nesting, noFollowFunc, seenObjects))
+                                    {
+                                        yield return result;
+                                    }
+                                    yield return ",\r\n";
                                 }
-                                yield return ",\r\n";
                             }
                         }
 

--- a/src/UnitTestCoder.Core/Literals/TypeNameLiteralMaker.cs
+++ b/src/UnitTestCoder.Core/Literals/TypeNameLiteralMaker.cs
@@ -14,35 +14,71 @@ namespace UnitTestCoder.Core.Literal
     {
         public string Literal(Type type, bool fullyQualify = false)
         {
-            return getNestedTypeName(type, fullyQualify, 0);
+            return getNestedTypeName(type, fullyQualify, fullyQualify, 0);
         }
 
 
-        private string getNestedTypeName(Type type, bool fullyQualify, int depth)
+        private string getNestedTypeName(Type type, bool fullyQualify, bool fqSub, int depth)
         {
+            if(type == null)
+                throw new ArgumentNullException(nameof(type));
+
             if(depth > 50)
                 throw new StackOverflowException();
 
-            var parts = new List<string>();
+            var nestings = new List<Type>();
+
+            // If it is a nested type, look back through DeclaringType so we can get back to the
+            // root type.
             while(type != null)
             {
-                parts.Add(getFullTypeName(type, fullyQualify, depth: depth + 1));
+                // TODO - limit nesting!!!
+                nestings.Add(type);
 
                 // Generic parameters e.g. T have the DeclaringType as the type they are part of
                 // so we must exit to avoid infinite loop.
                 if(type.IsGenericParameter)
                     break;
 
-                // Reached the end of the nesting.
-                if(!type.IsNested)
-                    break;
-
-                // Get the parent type or null if there is no class nesting
                 type = type.DeclaringType;
             }
 
-            // Results are in inner to outer order, reverse so we get Parent.Child.Grandchild
-            return String.Join(".", Enumerable.Reverse(parts));
+            // Reverse the order so the root type is first.
+
+            var parts = nestings.AsEnumerable().Reverse().Select((x, idx) =>
+                getFullTypeName(x,
+                   fullyQualify: (fullyQualify && idx == 0),  // Only fully qualify first item (outermost type)
+                   fqSub: fullyQualify,     // Sub elements need to be fully qualified?
+                   depth: depth + 1)
+            ).ToList();
+
+            //var parts = new List<string>();
+
+
+            //parts.Add(getFullTypeName(nestings.First(), 
+            //    fullyQualify,
+            //    fqSub: fullyQualify,
+            //    depth: depth + 1));
+            
+            
+
+            //while(type.IsNested)
+            //{
+            //    // Generic parameters e.g. T have the DeclaringType as the type they are part of
+            //    // so we must exit to avoid infinite loop.
+            //    if(type.IsGenericParameter)
+            //        break;
+                
+            //    parts.Add(type.Name);
+
+            //    // Get the parent type or null if there is no class nesting
+            //    type = type.DeclaringType;
+            //}
+
+            //parts.Add(getFullTypeName(type, fullyQualify, depth: depth + 1));
+
+
+            return String.Join(".",parts);
         }
 
         //https://stackoverflow.com/questions/1533115/get-generictype-name-in-good-format-using-reflection-on-c-sharp
@@ -51,12 +87,12 @@ namespace UnitTestCoder.Core.Literal
         /// </summary>
         /// <param name="t"></param>
         /// <returns></returns>
-        private string getFullTypeName(Type type, bool fullyQualify, int depth)
+        private string getFullTypeName(Type type, bool fullyQualify, bool fqSub, int depth)
         {
             // If this is a generic parameter (e.g. the T in List<T>) we should return an empty string
             // This is so we get an open generic type like typeof(IDictionary<,>)
             if(type.IsGenericParameter)
-                return "";
+                return "floop";
 
             if(type.IsArray)
             {
@@ -66,7 +102,7 @@ namespace UnitTestCoder.Core.Literal
                     + new string(',', (type.GetArrayRank() - 1))
                     + "]";
 
-                return getNestedTypeName(type.GetElementType(), fullyQualify, depth + 1) 
+                return getNestedTypeName(type.GetElementType(), fqSub, fqSub, depth + 1) 
                     + indexer;
             }
 
@@ -76,21 +112,36 @@ namespace UnitTestCoder.Core.Literal
                 return simple;
 
 
-            string typeName = fullyQualify && !type.IsNested ? type.FullName : type.Name;
+            string typeName = fullyQualify ? type.FullName : type.Name;
 
             // Non-generics, return the type name.
             if(!type.IsGenericType)
                 return typeName;
 
+            var gen = getNestedGenericArguments(type);
+            if(gen.Count == 0)
+                return typeName;
+
             // We will have something like List`T - we want the text before the backtick.
             string baseName = typeName.Substring(0, typeName.LastIndexOf("`"));
 
-            var genericArgs = String.Join(",", type.GetGenericArguments()
-                .Select(g => getNestedTypeName(g, fullyQualify, depth + 1)));
+            var genericArgs = String.Join(",", gen
+                .Select(g => getNestedTypeName(g, fqSub, fqSub, depth + 1)));
 
             return $"{baseName}<{genericArgs}>";
         }
 
+        private List<Type> getNestedGenericArguments(Type type)
+        {
+            if(!type.IsNested)
+                return type.GetGenericArguments().ToList();
+
+            // https://stackoverflow.com/questions/55051292/getting-generic-type-from-the-declaringtype-of-a-nested-type-in-c-sharp-with-ref
+            // For nested types, the generic arguments from the outer class are repeated on the inner.
+            // So we need to skip over these. I'm doing this by position, not sure this is the official
+            // way but it gives the right answer
+            return type.GetGenericArguments().Skip(type.DeclaringType.GetGenericArguments().Length).ToList();
+        }
         
         private string simpleTypeName(Type type)
         {

--- a/src/UnitTestCoder.Core/Literals/TypeNameLiteralMaker.cs
+++ b/src/UnitTestCoder.Core/Literals/TypeNameLiteralMaker.cs
@@ -39,11 +39,11 @@ namespace UnitTestCoder.Core.Literal
             int nestCount = 0;
             while(type != null)
             {
+                // Limit nesting
                 nestCount++;
                 if(nestCount > 50)
                     throw new StackOverflowException();
 
-                // TODO - limit nesting!!!
                 nestings.Add(type);
 
                 // Generic parameters e.g. T have the DeclaringType as the type they are part of

--- a/src/UnitTestCoder.Shouldly.Tests/Maker/ShouldlyTestMakerTests.cs
+++ b/src/UnitTestCoder.Shouldly.Tests/Maker/ShouldlyTestMakerTests.cs
@@ -425,6 +425,25 @@ namespace UnitTestCoder.Shouldly.Tests.Maker
             });
         }
 
+        [TestMethod]
+        public void ShouldlyTestMakerSkipItemProperty()
+        {
+            var myObj = new WithItemProperty() { Other = 123 };
+
+            var x = _shouldlyTestMaker.GenerateShouldBes("myObj", myObj).ToList();
+            x.ShouldBe(new[]
+            {
+                "myObj.ShouldNotBeNull();",
+                "myObj.Other.ShouldBe(123);"
+            });
+        }
+
+        private class WithItemProperty // NOT defined as IEnumerable / IList
+        {
+            public int this[int x] { get => 99; set { } }
+            public int Other { get; set; }
+        }
+
         public class NoFollowTestClass
         {
             public int IncludeThis { get; set; }


### PR DESCRIPTION
Multiple reliability improvements.
Works with nested generic types.
Skips over Item[] property when there is no IList to avoid this